### PR TITLE
Testing the CLI on Python 2.7.11

### DIFF
--- a/rancher-cli.py
+++ b/rancher-cli.py
@@ -22,11 +22,11 @@ def main():
     parser.add_argument('--stackName',
                         help='Stack name')
 
-    parser.add_argument('--stackUpgradeTimeout', default=os.environ.getenv('STACK_UPGRADE_TIMEOUT', 360),
+    parser.add_argument('--stackUpgradeTimeout', default=os.environ.get('STACK_UPGRADE_TIMEOUT', 360),
                         help='timeout for stack upgrade in seconds. Default 360')
-    parser.add_argument('--stackActiveTimeout', default=os.environ.getenv('STACK_ACTIVE_TIMEOUT', 360),
+    parser.add_argument('--stackActiveTimeout', default=os.environ.get('STACK_ACTIVE_TIMEOUT', 360),
                         help='timeout for stack become active in seconds. Default 360')
-    parser.add_argument('--stackHealthyTimeout', default=os.environ.getenv('STACK_HEALTHY_TIMEOUT', 360),
+    parser.add_argument('--stackHealthyTimeout', default=os.environ.get('STACK_HEALTHY_TIMEOUT', 360),
                         help='timeout for stack become healthy in seconds. Default 360')
 
     parser.add_argument('--dockerCompose',

--- a/rancher/stack.py
+++ b/rancher/stack.py
@@ -71,7 +71,6 @@ class Stack:
                       'dockerCompose': docker_compose,
                       'rancherCompose': rancher_compose}
         payload = util.build_payload(stack_data)
-
         end_point = self.config[
                         'rancherBaseUrl'] + self.rancherApiVersion + 'environment'
         response = requests.post(end_point,
@@ -133,7 +132,7 @@ class Stack:
 
     def __wait_for_upgrade(self, stack_id):
         print 'Let`s wait until stack upgraded...'
-        timeout = self.config.stackUpgradeTimeout
+        timeout = self.config['stackUpgradeTimeout']
         stop_time = int(time()) + timeout
         state = None
         while int(time()) <= stop_time:
@@ -146,7 +145,7 @@ class Stack:
 
     def __wait_for_active(self, stack_id):
         print 'Let`s wait until stack become active...'
-        timeout = self.config.stackActiveTimeout
+        timeout = self.config['stackActiveTimeout']
         stop_time = int(time()) + timeout
         state = None
         while int(time()) <= stop_time:
@@ -159,7 +158,7 @@ class Stack:
 
     def __wait_for_healthy(self, stack_id):
         print 'Let`s wait until stack become healthy...'
-        timeout = self.config.stackHealthyTimeout
+        timeout = self.config['stackHealthyTimeout']
         stop_time = int(time()) + timeout
         health_state = None
         while int(time()) <= stop_time:


### PR DESCRIPTION
Hello

Thanks for your project :).

Sorry if my request has no sense, I'm not a developer but if I want to upgrade a stack, I need to change some accessors. 
I use the following command with environment variables: 

``` bash
python rancher-cli.py --action=create-stack --stackName=HelloWorld --dockerCompose=../rancher-stacks/helloworld.docker-compose.yml --rancherCompose=../rancher-stacks/helloworld.rancher-compose.yml
```

``` diff
-        timeout = self.config.stackHealthyTimeout
+        timeout = self.config['stackHealthyTimeout']

```

``` bash
Let`s wait until stack upgraded...
Traceback (most recent call last):
  File "rancher-cli.py", line 99, in <module>
    main()
  File "rancher-cli.py", line 93, in main
    stack.Stack(config).create(args.stackName, args.dockerCompose, args.rancherCompose, stack_environment)
  File "/root/Project/rancher-cli-addons/rancher/stack.py", line 86, in create
    self.upgrade(name, docker_compose_path, rancher_compose_path)
  File "/root/Project/rancher-cli-addons/rancher/stack.py", line 197, in upgrade
    self.__wait_for_upgrade(stack_id)
  File "/root/Project/rancher-cli-addons/rancher/stack.py", line 139, in __wait_for_upgrade
    print self.config.__dict__
AttributeError: 'dict' object has no attribute '__dict__'
```

Same for usage: 

``` diff
-    parser.add_argument('--stackUpgradeTimeout', default=os.environ.getenv('STACK_UPGRADE_TIMEOUT', 360),
+    parser.add_argument('--stackUpgradeTimeout', default=os.environ.get('STACK_UPGRADE_TIMEOUT', 360),
```

``` bash
# python rancher-cli-addons/rancher-cli.py 
Traceback (most recent call last):
  File "rancher-cli-addons/rancher-cli.py", line 99, in <module>
    main()
  File "rancher-cli-addons/rancher-cli.py", line 25, in main
    parser.add_argument('--stackUpgradeTimeout', default=os.environ.getenv('STACK_UPGRADE_TIMEOUT', 360),
AttributeError: _Environ instance has no attribute 'getenv'
```

Regards
